### PR TITLE
Fixed bug in to_sql with where clause contianing In statements with a single value. i.e. id IN (123)

### DIFF
--- a/lib/sql-parser/sql_visitor.rb
+++ b/lib/sql-parser/sql_visitor.rb
@@ -346,7 +346,7 @@ module SQLParser
     end
 
     def arrayize(arr)
-      visit_all(arr).join(', ')
+      visit_all(Array.wrap(arr)).join(', ')
     end
 
     def aggregate(function_name, o)


### PR DESCRIPTION
Make sure that arrayize always sends an array to visit_all. This fixes issues with InValueLists with one value. I.E SELECT \* FROM foo WHERE id IN (123)
